### PR TITLE
Hide I2C-Marg configuration until generalized init is available

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,9 +55,10 @@ Examples include: reading temperature, calibrating magnetrometer, reading all se
 
 Expiremntal I2C support is enabled via `i2c` feature flag. When enabled, SPI support will be deactivated
 and type of mpu9250 driver will change from `Mpu9250<SpiDevice<SPI, NCS>, MODE>` will change to
-`Mpu9250<I2cDevice<I2C>, MODE>`.
+`Mpu9250<I2cDevice<I2C>, Imu>`.
 
-NOTE: I2C support is not properly tested yet.
+The MPU9250 currently supports an IMU-only configuration. See the [BeagleBone Blue example](examples/bbblue.rs)
+for a demonstration. Support for the AK8963 is a WPI.
 
 ## Documentation
 

--- a/examples/bbblue.rs
+++ b/examples/bbblue.rs
@@ -27,7 +27,7 @@ fn main() -> io::Result<()> {
 
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
-    writeln!(&mut stdout, "   Accel XYZ(m/s^2)  |   Gyro XYZ (deg/s)  |")?;
+    writeln!(&mut stdout, "   Accel XYZ(m/s^2)  |   Gyro XYZ (rad/s)  |")?;
     loop {
         let all = mpu9250.all().expect("unable to read from MPU!");
         write!(&mut stdout,

--- a/examples/bbblue.rs
+++ b/examples/bbblue.rs
@@ -6,6 +6,7 @@
 extern crate linux_embedded_hal as hal;
 extern crate mpu9250;
 
+use std::io::{self, Write};
 use std::thread;
 use std::time::Duration;
 
@@ -13,19 +14,31 @@ use hal::Delay;
 use hal::I2cdev;
 use mpu9250::Mpu9250;
 
-fn main() {
+fn main() -> io::Result<()> {
     let i2c = I2cdev::new("/dev/i2c-2").expect("unable to open /dev/i2c-2");
 
-    let mut mpu9250 = Mpu9250::marg_default(i2c, &mut Delay).expect("unable to make MPU9250");
+    let mut mpu9250 =
+        Mpu9250::imu_default(i2c, &mut Delay).expect("unable to make MPU9250");
 
     let who_am_i = mpu9250.who_am_i().expect("could not read WHO_AM_I");
 
     println!("WHO_AM_I: 0x{:x}", who_am_i);
     assert_eq!(who_am_i, 0x71);
 
-    println!("{:#?}", mpu9250.all().expect("could not perform first read all"));
-
-    thread::sleep(Duration::from_millis(100));
-
-    println!("{:#?}", mpu9250.all().unwrap());
+    let stdout = io::stdout();
+    let mut stdout = stdout.lock();
+    writeln!(&mut stdout, "   Accel XYZ(m/s^2)  |   Gyro XYZ (deg/s)  |")?;
+    loop {
+        let all = mpu9250.all().expect("unable to read from MPU!");
+        write!(&mut stdout,
+               "\r{:>6.2} {:>6.2} {:>6.2} |{:>6.1} {:>6.1} {:>6.1} |",
+               all.accel[0],
+               all.accel[1],
+               all.accel[2],
+               all.gyro[0],
+               all.gyro[1],
+               all.gyro[2])?;
+        stdout.flush()?;
+        thread::sleep(Duration::from_micros(100000));
+    }
 }

--- a/examples/bbblue.rs
+++ b/examples/bbblue.rs
@@ -27,17 +27,18 @@ fn main() -> io::Result<()> {
 
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
-    writeln!(&mut stdout, "   Accel XYZ(m/s^2)  |   Gyro XYZ (rad/s)  |")?;
+    writeln!(&mut stdout, "   Accel XYZ(m/s^2)  |   Gyro XYZ (rad/s)  | Temp (C)")?;
     loop {
         let all = mpu9250.all().expect("unable to read from MPU!");
         write!(&mut stdout,
-               "\r{:>6.2} {:>6.2} {:>6.2} |{:>6.1} {:>6.1} {:>6.1} |",
+               "\r{:>6.2} {:>6.2} {:>6.2} |{:>6.1} {:>6.1} {:>6.1} | {:>4.1} ",
                all.accel[0],
                all.accel[1],
                all.accel[2],
                all.gyro[0],
                all.gyro[1],
-               all.gyro[2])?;
+               all.gyro[2],
+               all.temp)?;
         stdout.flush()?;
         thread::sleep(Duration::from_micros(100000));
     }

--- a/examples/bbblue.rs
+++ b/examples/bbblue.rs
@@ -27,7 +27,8 @@ fn main() -> io::Result<()> {
 
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
-    writeln!(&mut stdout, "   Accel XYZ(m/s^2)  |   Gyro XYZ (rad/s)  | Temp (C)")?;
+    writeln!(&mut stdout,
+             "   Accel XYZ(m/s^2)  |   Gyro XYZ (rad/s)  | Temp (C)")?;
     loop {
         let all = mpu9250.all().expect("unable to read from MPU!");
         write!(&mut stdout,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,35 +272,43 @@ mod i2c_defs {
         }
     }
 
-    impl<E, I2C> Mpu9250<I2cDevice<I2C>, Marg>
-        where I2C: i2c::Read<Error = E>
-                  + i2c::Write<Error = E>
-                  + i2c::WriteRead<Error = E>
-    {
-        /// Creates a new [`Marg`] driver from an I2C peripheral with
-        /// default [`Config`].
-        ///
-        /// [`Config`]: ./conf/struct.MpuConfig.html
-        pub fn marg_default<D>(i2c: I2C,
-                               delay: &mut D)
-                               -> Result<Self, Error<E>>
-            where D: DelayMs<u8>
+    /// We need to generalize the AK8963 initialization (init_ak8963()) for both
+    /// SPI and I2C devices. See an example of I2C AK8963 bringup:
+    /// https://github.com/StrawsonDesign/librobotcontrol/blob/master/library/src/mpu/mpu.c#L592
+    /// 
+    /// Until something like that is in place, this code path is broken and unreachable.
+    mod broken {
+        use super::*;
+        impl<E, I2C> Mpu9250<I2cDevice<I2C>, Marg>
+            where I2C: i2c::Read<Error = E>
+                      + i2c::Write<Error = E>
+                      + i2c::WriteRead<Error = E>
         {
-            Mpu9250::marg(i2c, delay, &mut MpuConfig::marg())
-        }
+            /// Creates a new [`Marg`] driver from an I2C peripheral with
+            /// default [`Config`].
+            ///
+            /// [`Config`]: ./conf/struct.MpuConfig.html
+            pub fn marg_default<D>(i2c: I2C,
+                                   delay: &mut D)
+                                   -> Result<Self, Error<E>>
+                where D: DelayMs<u8>
+            {
+                Mpu9250::marg(i2c, delay, &mut MpuConfig::marg())
+            }
 
-        /// Creates a new MARG driver from an I2C peripheral
-        /// with provided configuration [`Config`].
-        ///
-        /// [`Config`]: ./conf/struct.MpuConfig.html
-        pub fn marg<D>(i2c: I2C,
-                       delay: &mut D,
-                       config: &mut MpuConfig<Marg>)
-                       -> Result<Self, Error<E>>
-            where D: DelayMs<u8>
-        {
-            let dev = I2cDevice::new(i2c);
-            Self::new_marg(dev, delay, config)
+            /// Creates a new MARG driver from an I2C peripheral
+            /// with provided configuration [`Config`].
+            ///
+            /// [`Config`]: ./conf/struct.MpuConfig.html
+            pub fn marg<D>(i2c: I2C,
+                           delay: &mut D,
+                           config: &mut MpuConfig<Marg>)
+                           -> Result<Self, Error<E>>
+                where D: DelayMs<u8>
+            {
+                let dev = I2cDevice::new(i2c);
+                Self::new_marg(dev, delay, config)
+            }
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,6 @@
 //! [4]: https://github.com/copterust/proving-ground
 
 #![deny(missing_docs)]
-#![allow(warnings)]
 #![no_std]
 
 #[macro_use]
@@ -66,7 +65,6 @@ mod device;
 mod types;
 
 use core::marker::PhantomData;
-use core::mem;
 
 use cast::{f32, i32, u16};
 use generic_array::typenum::consts::*;
@@ -75,9 +73,6 @@ use nalgebra::convert;
 pub use nalgebra::Vector3;
 
 use hal::blocking::delay::DelayMs;
-use hal::blocking::i2c;
-use hal::blocking::spi;
-use hal::digital::OutputPin;
 use hal::spi::{Mode, Phase, Polarity};
 
 pub use conf::*;
@@ -160,6 +155,8 @@ const TEMP_ROOM_OFFSET: f32 = 0.0;
 #[cfg(not(feature = "i2c"))]
 mod spi_defs {
     use super::*;
+    use hal::blocking::spi;
+    use hal::digital::OutputPin;
 
     // SPI device, 6DOF
     impl<E, SPI, NCS> Mpu9250<SpiDevice<SPI, NCS>, Imu>
@@ -245,6 +242,7 @@ pub use spi_defs::*;
 #[cfg(feature = "i2c")]
 mod i2c_defs {
     use super::*;
+    use hal::blocking::i2c;
 
     impl<E, I2C> Mpu9250<I2cDevice<I2C>, Imu>
         where I2C: i2c::Read<Error = E>


### PR DESCRIPTION
I believe I figured out why the BeagleBone Blue example wasn't working: the [`init_ak8963` method](https://github.com/copterust/mpu9250/blob/master/src/lib.rs#L436) assumes that we're configuring the AK8963 over a SPI connection, which causes mishap if we're actually using I2C. When bringing-up the magnetometer using an I2C connection, we need a different configuration path. I'm studying the example [here](https://github.com/StrawsonDesign/librobotcontrol/blob/master/library/src/mpu/mpu.c#L592) as a way of configuring the AK8963 over I2C.

Until I separate AK8963 initialization based on SPI / I2C, this pull request disables support for a Marg-enabled MPU over I2C. However, an IMU-over-I2C works!. The pull request updates the BeagleBone Blue example to demonstrate an IMU-based MPU, and updates the docs accordingly:

[![asciicast](https://asciinema.org/a/231348.svg)](https://asciinema.org/a/231348)

Let me know if we'd rather wait to merge this in. I figured this would unblock anyone who wanted to start using and IMU-based MPU over I2C.