### PR TITLE
Allow changing SPI settings after initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- `imu_with_reinit` and `marg_with_reinit` consturctor for MPU9250 via SPI.
+   These functions allow supplying callback that will be called after initialization is done
+   to optionally reconfigure underlying bus, e.g. change speed.
+
 ## [v0.9.2] - 2019-02-26
 
 ### Changed


### PR DESCRIPTION
Adds new constructors: `imu_with_reinit` and `marg_with_reinit` for
MPU9250 over SPI. These functions accept re-initialization function
that will be called after initialization and that can be used to
change bus settings, e.g. speed. As HAL implementatinos crates often
don't provide methods for changing speed, re-init function consumes
bus and has to return new instance back:

Example

```rust:

let mut mpu = Mpu9250::imu_with_reinit(
    spi,
    ncs,
    &mut delay,
    &mut mpu9250::MpuConfig::imu(),
    |spi, ncs| {
        let (dev_spi, (scl, miso, mosi)) = spi.free();
        let new_spi = dev_spi.spi((scl, miso, mosi), mpu9250::MODE, 20.mhz(), clocks);
        Some((new_spi, ncs))
    },
).unwrap();
```

Note, that `callibrate_at_rest` function may be called after bus has
been reconfigured.