### PR TITLE
Enable I2C Bypass for AK8963 communications

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ repository = "https://github.com/copterust/mpu9250"
 embedded-hal = "0.2.2"
 generic-array = "0.12.0"
 bitflags = "1.0"
-log = "0.4"
 
 [dependencies.cast]
 default-features = false
@@ -24,7 +23,6 @@ version = "0.16.4"
 
 [dev-dependencies]
 linux-embedded-hal = "0.2"
-env_logger = "0.6"
 
 [features]
 # Enable the I2C MPU interface. This disables the SPI interface. All function

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/copterust/mpu9250"
 embedded-hal = "0.2.2"
 generic-array = "0.12.0"
 bitflags = "1.0"
+log = "0.4"
 
 [dependencies.cast]
 default-features = false
@@ -23,6 +24,7 @@ version = "0.16.4"
 
 [dev-dependencies]
 linux-embedded-hal = "0.2"
+env_logger = "0.6"
 
 [features]
 # Enable the I2C MPU interface. This disables the SPI interface. All function

--- a/examples/bbblue.rs
+++ b/examples/bbblue.rs
@@ -15,7 +15,6 @@ use hal::I2cdev;
 use mpu9250::Mpu9250;
 
 fn main() -> io::Result<()> {
-    env_logger::init();
     let i2c = I2cdev::new("/dev/i2c-2").expect("unable to open /dev/i2c-2");
 
     let mut mpu9250 =

--- a/examples/bbblue.rs
+++ b/examples/bbblue.rs
@@ -15,30 +15,35 @@ use hal::I2cdev;
 use mpu9250::Mpu9250;
 
 fn main() -> io::Result<()> {
+    env_logger::init();
     let i2c = I2cdev::new("/dev/i2c-2").expect("unable to open /dev/i2c-2");
 
     let mut mpu9250 =
-        Mpu9250::imu_default(i2c, &mut Delay).expect("unable to make MPU9250");
+        Mpu9250::marg_default(i2c, &mut Delay).expect("unable to make MPU9250");
 
     let who_am_i = mpu9250.who_am_i().expect("could not read WHO_AM_I");
-
+    let mag_who_am_i = mpu9250.ak8963_who_am_i().expect("could not read magnetometer's WHO_AM_I");
     println!("WHO_AM_I: 0x{:x}", who_am_i);
+    println!("AK8963 WHO_AM_I: 0x{:x}", mag_who_am_i);
     assert_eq!(who_am_i, 0x71);
 
     let stdout = io::stdout();
     let mut stdout = stdout.lock();
     writeln!(&mut stdout,
-             "   Accel XYZ(m/s^2)  |   Gyro XYZ (rad/s)  | Temp (C)")?;
+             "   Accel XYZ(m/s^2)  |   Gyro XYZ (rad/s)  |  Mag Field XYZ(uT)  | Temp (C)")?;
     loop {
         let all = mpu9250.all().expect("unable to read from MPU!");
         write!(&mut stdout,
-               "\r{:>6.2} {:>6.2} {:>6.2} |{:>6.1} {:>6.1} {:>6.1} | {:>4.1} ",
+               "\r{:>6.2} {:>6.2} {:>6.2} |{:>6.1} {:>6.1} {:>6.1} |{:>6.1} {:>6.1} {:>6.1} | {:>4.1} ",
                all.accel[0],
                all.accel[1],
                all.accel[2],
                all.gyro[0],
                all.gyro[1],
                all.gyro[2],
+               all.mag[0],
+               all.mag[1],
+               all.mag[2],
                all.temp)?;
         stdout.flush()?;
         thread::sleep(Duration::from_micros(100000));

--- a/src/ak8963.rs
+++ b/src/ak8963.rs
@@ -37,14 +37,6 @@ impl Register {
     pub fn addr(&self) -> u8 {
         *self as u8
     }
-
-    pub fn read_address(&self) -> u8 {
-        self.addr() | R
-    }
-
-    pub fn write_address(&self) -> u8 {
-        self.addr() | W
-    }
 }
 
 /// Decribes a type that can communicate with the

--- a/src/ak8963.rs
+++ b/src/ak8963.rs
@@ -54,6 +54,12 @@ pub trait AK8963 {
                             delay: &mut D)
                             -> Result<(), Self::Error>;
 
+    /// Perform final initialization. Invoked after acquiring the magnetomter's
+    /// calibration values and setting the sampling rate and resolution.
+    fn finalize<D: DelayMs<u8>>(&mut self, _: &mut D) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
     /// Read a magnetometer's register
     fn read(&mut self, reg: Register) -> Result<u8, Self::Error>;
 

--- a/src/ak8963.rs
+++ b/src/ak8963.rs
@@ -1,5 +1,10 @@
 //! AK8963, I2C magnetometer
 
+use hal::blocking::delay::DelayMs;
+
+use generic_array::typenum::consts::*;
+use generic_array::GenericArray;
+
 // I2C slave address
 pub const I2C_ADDRESS: u8 = 0x0c;
 pub const R: u8 = 1 << 7;
@@ -32,4 +37,37 @@ impl Register {
     pub fn addr(&self) -> u8 {
         *self as u8
     }
+
+    pub fn read_address(&self) -> u8 {
+        self.addr() | R
+    }
+
+    pub fn write_address(&self) -> u8 {
+        self.addr() | W
+    }
+}
+
+/// Decribes a type that can communicate with the
+/// MPU's on-board magnetometer, the AK8963
+pub trait AK8963 {
+    /// Associated error type
+    type Error;
+
+    /// Initialize the AK8963
+    ///
+    /// It may not make sense to call this more than once. However, it is
+    /// absolutely necessary to call it at least once if you need the
+    /// magnetometer
+    fn init<D: DelayMs<u8>>(&mut self,
+                            delay: &mut D)
+                            -> Result<(), Self::Error>;
+
+    /// Read a magnetometer's register
+    fn read(&mut self, reg: Register) -> Result<u8, Self::Error>;
+
+    /// Write to a magnetometer's register
+    fn write(&mut self, reg: Register, value: u8) -> Result<(), Self::Error>;
+
+    /// Read the magnetometer's X,Y,Z triplet
+    fn read_xyz(&mut self) -> Result<GenericArray<u8, U7>, Self::Error>;
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -146,6 +146,21 @@ impl<SPI, NCS, E> AK8963 for SpiDevice<SPI, NCS>
         Ok(())
     }
 
+    fn finalize<D: DelayMs<u8>>(&mut self, delay: &mut D) -> Result<(), Self::Error> {
+        // set aux I2C frequency to 400 KHz (should be configurable?)
+        Device::write(self, Register::I2C_MST_CTRL, 0x0d)?;
+
+        delay.delay_ms(10);
+
+        // configure sampling of magnetometer
+        Device::write(self, Register::I2C_SLV0_ADDR, ak8963::I2C_ADDRESS | ak8963::R)?;
+        Device::write(self, Register::I2C_SLV0_REG, ak8963::Register::XOUT_L.addr())?;
+        Device::write(self, Register::I2C_SLV0_CTRL, 0x87)?;
+
+        delay.delay_ms(10);
+        Ok(())
+    }
+
     fn read(&mut self, reg: ak8963::Register) -> Result<u8, Self::Error> {
         Device::write(self,
                       Register::I2C_SLV4_ADDR,

--- a/src/device.rs
+++ b/src/device.rs
@@ -1,5 +1,8 @@
+use ak8963::{self, AK8963};
+
 use core::mem;
 
+use hal::blocking::delay::DelayMs;
 use hal::blocking::i2c;
 use hal::blocking::spi;
 use hal::digital::OutputPin;
@@ -8,6 +11,9 @@ use generic_array::typenum::consts::*;
 use generic_array::{ArrayLength, GenericArray};
 
 use Register;
+
+/// MPU's I2C address (AD0 low)
+const MPU_I2C_ADDR: u8 = 0x68;
 
 /// Releasable describes a type that can be destroyed
 /// with a released asset.
@@ -123,6 +129,62 @@ impl<SPI, NCS, E> Device for SpiDevice<SPI, NCS>
     }
 }
 
+impl<SPI, NCS, E> AK8963 for SpiDevice<SPI, NCS>
+    where SPI: spi::Write<u8, Error = E> + spi::Transfer<u8, Error = E>,
+          NCS: OutputPin
+{
+    type Error = E;
+
+    fn init<D: DelayMs<u8>>(&mut self,
+                            delay: &mut D)
+                            -> Result<(), Self::Error> {
+        // Isolate the auxiliary master I2C bus (AUX_CL, AUX_DA)
+        // disable the slave I2C bus, make serial interface SPI only
+        // reset the master I2C bus
+        Device::write(self, Register::USER_CTRL, 0x32)?;
+        delay.delay_ms(10);
+        Ok(())
+    }
+
+    fn read(&mut self, reg: ak8963::Register) -> Result<u8, Self::Error> {
+        Device::write(self,
+                      Register::I2C_SLV4_ADDR,
+                      ak8963::I2C_ADDRESS | ak8963::R)?;
+        Device::write(self, Register::I2C_SLV4_REG, reg.addr())?;
+
+        // start transfer
+        Device::write(self, Register::I2C_SLV4_CTRL, 0x80)?;
+
+        // wait until transfer is over
+        while Device::read(self, Register::I2C_MST_STATUS)? & (1 << 6) == 0 {}
+
+        Device::read(self, Register::I2C_SLV4_DI)
+    }
+
+    fn write(&mut self,
+             reg: ak8963::Register,
+             value: u8)
+             -> Result<(), Self::Error> {
+        Device::write(self,
+                      Register::I2C_SLV4_ADDR,
+                      ak8963::I2C_ADDRESS | ak8963::W)?;
+        Device::write(self, Register::I2C_SLV4_REG, reg.addr())?;
+        Device::write(self, Register::I2C_SLV4_DO, value)?;
+
+        // start transfer
+        Device::write(self, Register::I2C_SLV4_CTRL, 0x80)?;
+
+        // wait until transfer is over
+        while Device::read(self, Register::I2C_MST_STATUS)? & (1 << 6) == 0 {}
+
+        Ok(())
+    }
+
+    fn read_xyz(&mut self) -> Result<GenericArray<u8, U7>, Self::Error> {
+        Device::read_many::<U7>(self, Register::EXT_SENS_DATA_00)
+    }
+}
+
 /// An I2C device. Use I2CDevice when the
 /// MPU9250 is connected via I2C
 pub struct I2cDevice<I2C> {
@@ -152,8 +214,6 @@ impl<E, I2C> Releasable for I2cDevice<I2C>
     }
 }
 
-// TODO don't hard-code 0x68 in any of these...
-// TODO then figure out how to handle mag passthrough...
 impl<E, I2C> Device for I2cDevice<I2C>
     where I2C: i2c::Read<Error = E>
               + i2c::Write<Error = E>
@@ -168,15 +228,77 @@ impl<E, I2C> Device for I2cDevice<I2C>
         let mut buffer: GenericArray<u8, N> = unsafe { mem::zeroed() };
         {
             let slice: &mut [u8] = &mut buffer;
-            self.i2c
-                .write_read(0x68, &[reg.read_address()], &mut slice[1..])?;
+            self.i2c.write_read(MPU_I2C_ADDR,
+                                 &[reg as u8],
+                                 &mut slice[1..])?;
         }
 
         Ok(buffer)
     }
 
     fn write(&mut self, reg: Register, val: u8) -> Result<(), Self::Error> {
-        let buff: [u8; 2] = [reg.write_address(), val];
-        self.i2c.write(0x68, &buff)
+        let buff: [u8; 2] = [reg as u8, val];
+        self.i2c.write(MPU_I2C_ADDR, &buff)
+    }
+}
+
+impl<I2C, E> AK8963 for I2cDevice<I2C>
+    where I2C: i2c::Read<Error = E>
+              + i2c::Write<Error = E>
+              + i2c::WriteRead<Error = E>
+{
+    type Error = E;
+
+    fn init<D: DelayMs<u8>>(&mut self,
+                            delay: &mut D)
+                            -> Result<(), Self::Error> {
+        log::trace!("Zeroing USER_CTRL...");
+        Device::write(self, Register::USER_CTRL, 0)?;
+        delay.delay_ms(10);
+
+        log::trace!("Setting I2C bypass...");
+        const LATCH_INT_EN: u8 = 1 << 5;
+        const INT_ANYRD_CLEAR: u8 = 1 << 4;
+        const ACTL_ACTIVE_LOW: u8 = 1 << 7;
+        const BYPASS_EN: u8 = 1 << 1;
+        Device::write(self,
+                      Register::INT_PIN_CFG,
+                      LATCH_INT_EN
+                      | INT_ANYRD_CLEAR
+                      | ACTL_ACTIVE_LOW
+                      | BYPASS_EN)?;
+        delay.delay_ms(10);
+
+        Ok(())
+    }
+
+    fn read(&mut self, reg: ak8963::Register) -> Result<u8, Self::Error> {
+        let mut buffer = [0; 1];
+        self.i2c.write_read(ak8963::I2C_ADDRESS,
+                             &[reg.addr()],
+                             &mut buffer)?;
+        Ok(buffer[0])
+    }
+
+    fn write(&mut self,
+             reg: ak8963::Register,
+             value: u8)
+             -> Result<(), Self::Error> {
+        let buff: [u8; 2] = [reg.addr(), value];
+        self.i2c.write(ak8963::I2C_ADDRESS, &buff)
+    }
+
+    fn read_xyz(&mut self) -> Result<GenericArray<u8, U7>, Self::Error> {
+        let mut buffer: GenericArray<u8, U7> = unsafe { mem::zeroed() };
+        {
+            let slice: &mut [u8] = &mut buffer;
+            self.i2c.write_read(ak8963::I2C_ADDRESS,
+                                 &[ak8963::Register::XOUT_L.addr()],
+                                 &mut slice[1..])?;
+        }
+        // Required to read ST2 after axes, otherwise
+        // we stop sampling
+        AK8963::read(self, ak8963::Register::ST2)?;
+        Ok(buffer)
     }
 }

--- a/src/device.rs
+++ b/src/device.rs
@@ -252,11 +252,9 @@ impl<I2C, E> AK8963 for I2cDevice<I2C>
     fn init<D: DelayMs<u8>>(&mut self,
                             delay: &mut D)
                             -> Result<(), Self::Error> {
-        log::trace!("Zeroing USER_CTRL...");
         Device::write(self, Register::USER_CTRL, 0)?;
         delay.delay_ms(10);
 
-        log::trace!("Setting I2C bypass...");
         const LATCH_INT_EN: u8 = 1 << 5;
         const INT_ANYRD_CLEAR: u8 = 1 << 4;
         const ACTL_ACTIVE_LOW: u8 = 1 << 7;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -570,15 +570,7 @@ impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E> + AK8963<Error = E>
         self._mag_scale()?;
         delay.delay_ms(10);
         
-        // // set aux I2C frequency to 400 KHz (should be configurable?)
-        // Device::write(&mut self.dev, Register::I2C_MST_CTRL, 0x0d)?;
-
-        // delay.delay_ms(10);
-
-        // // configure sampling of magnetometer
-        // Device::write(&mut self.dev, Register::I2C_SLV0_ADDR, ak8963::I2C_ADDRESS | ak8963::R)?;
-        // Device::write(&mut self.dev, Register::I2C_SLV0_REG, ak8963::Register::XOUT_L.addr())?;
-        // Device::write(&mut self.dev, Register::I2C_SLV0_CTRL, 0x87)?;
+        AK8963::finalize(&mut self.dev, delay)?;
 
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,8 @@ mod conf;
 mod device;
 mod types;
 
+use ak8963::AK8963;
+
 use core::marker::PhantomData;
 
 use cast::{f32, i32, u16};
@@ -272,43 +274,35 @@ mod i2c_defs {
         }
     }
 
-    /// We need to generalize the AK8963 initialization (init_ak8963()) for both
-    /// SPI and I2C devices. See an example of I2C AK8963 bringup:
-    /// https://github.com/StrawsonDesign/librobotcontrol/blob/master/library/src/mpu/mpu.c#L592
-    /// 
-    /// Until something like that is in place, this code path is broken and unreachable.
-    mod broken {
-        use super::*;
-        impl<E, I2C> Mpu9250<I2cDevice<I2C>, Marg>
-            where I2C: i2c::Read<Error = E>
-                      + i2c::Write<Error = E>
-                      + i2c::WriteRead<Error = E>
+    impl<E, I2C> Mpu9250<I2cDevice<I2C>, Marg>
+        where I2C: i2c::Read<Error = E>
+                  + i2c::Write<Error = E>
+                  + i2c::WriteRead<Error = E>
+    {
+        /// Creates a new [`Marg`] driver from an I2C peripheral with
+        /// default [`Config`].
+        ///
+        /// [`Config`]: ./conf/struct.MpuConfig.html
+        pub fn marg_default<D>(i2c: I2C,
+                               delay: &mut D)
+                               -> Result<Self, Error<E>>
+            where D: DelayMs<u8>
         {
-            /// Creates a new [`Marg`] driver from an I2C peripheral with
-            /// default [`Config`].
-            ///
-            /// [`Config`]: ./conf/struct.MpuConfig.html
-            pub fn marg_default<D>(i2c: I2C,
-                                   delay: &mut D)
-                                   -> Result<Self, Error<E>>
-                where D: DelayMs<u8>
-            {
-                Mpu9250::marg(i2c, delay, &mut MpuConfig::marg())
-            }
+            Mpu9250::marg(i2c, delay, &mut MpuConfig::marg())
+        }
 
-            /// Creates a new MARG driver from an I2C peripheral
-            /// with provided configuration [`Config`].
-            ///
-            /// [`Config`]: ./conf/struct.MpuConfig.html
-            pub fn marg<D>(i2c: I2C,
-                           delay: &mut D,
-                           config: &mut MpuConfig<Marg>)
-                           -> Result<Self, Error<E>>
-                where D: DelayMs<u8>
-            {
-                let dev = I2cDevice::new(i2c);
-                Self::new_marg(dev, delay, config)
-            }
+        /// Creates a new MARG driver from an I2C peripheral
+        /// with provided configuration [`Config`].
+        ///
+        /// [`Config`]: ./conf/struct.MpuConfig.html
+        pub fn marg<D>(i2c: I2C,
+                       delay: &mut D,
+                       config: &mut MpuConfig<Marg>)
+                       -> Result<Self, Error<E>>
+            where D: DelayMs<u8>
+        {
+            let dev = I2cDevice::new(i2c);
+            Self::new_marg(dev, delay, config)
         }
     }
 
@@ -403,7 +397,7 @@ impl<E, DEV> Mpu9250<DEV, Imu> where DEV: Device<Error = E>
 }
 
 // Any device, 9DOF
-impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E>
+impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E> + AK8963<Error = E>
 {
     // Private constructor that creates a MARG-based MPU with
     // the specificed device.
@@ -442,47 +436,45 @@ impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E>
     fn init_ak8963<D>(&mut self, delay: &mut D) -> Result<(), E>
         where D: DelayMs<u8>
     {
-        // isolate the auxiliary master I2C bus (AUX_CL, AUX_DA)
-        // disable the slave I2C bus, make serial interface SPI only
-        // reset the master I2C bus
-        self.dev.write(Register::USER_CTRL, 0x32)?;
-
+        log::trace!("Initializing AK8963...");
+        AK8963::init(&mut self.dev, delay)?;
+        delay.delay_ms(10);
         // First extract the factory calibration for each magnetometer axis
-        // Power down magnetometer
-        self.ak8963_write(ak8963::Register::CNTL, 0x00)?;
+        log::trace!("Powering down AK8963...");
+        AK8963::write(&mut self.dev, ak8963::Register::CNTL, 0x00)?;
         delay.delay_ms(10);
-        // Enter Fuse ROM access mode
-        self.ak8963_write(ak8963::Register::CNTL, 0x0F)?;
-        delay.delay_ms(10);
-        // Read the x-, y-, and z-axis calibration values
-        let mag_x_bias = self.ak8963_read(ak8963::Register::ASAX)?;
-        let mag_y_bias = self.ak8963_read(ak8963::Register::ASAY)?;
-        let mag_z_bias = self.ak8963_read(ak8963::Register::ASAZ)?;
+        
+        log::trace!("Entering FUSE mode...");
+        AK8963::write(&mut self.dev, ak8963::Register::CNTL, 0x0F)?;
+        delay.delay_ms(20);
+        log::trace!("Reading calibration values...");
+        let mag_x_bias = AK8963::read(&mut self.dev, ak8963::Register::ASAX)?;
+        let mag_y_bias = AK8963::read(&mut self.dev, ak8963::Register::ASAY)?;
+        let mag_z_bias = AK8963::read(&mut self.dev, ak8963::Register::ASAZ)?;
         // Return x-axis sensitivity adjustment values, etc.
         self.raw_mag_sensitivity_adjustments =
             Vector3::new(mag_x_bias, mag_y_bias, mag_z_bias);
         self.mag_sensitivity_adjustments =
             self.raw_mag_sensitivity_adjustments
                 .map(|d| f32(d - 128) / 256. + 1.);
-        self.ak8963_write(ak8963::Register::CNTL, 0x00)?;
+        log::trace!("Magnetometer sensitivity adjustments = {:?}", self.mag_sensitivity_adjustments);
+        AK8963::write(&mut self.dev, ak8963::Register::CNTL, 0x00)?;
         delay.delay_ms(10);
         // Set magnetometer data resolution and sample ODR
         self._mag_scale()?;
         delay.delay_ms(10);
+        
+        // // set aux I2C frequency to 400 KHz (should be configurable?)
+        // Device::write(&mut self.dev, Register::I2C_MST_CTRL, 0x0d)?;
 
-        // set aux I2C frequency to 400 KHz (should be configurable?)
-        self.dev.write(Register::I2C_MST_CTRL, 0x0d)?;
+        // delay.delay_ms(10);
 
-        delay.delay_ms(10);
+        // // configure sampling of magnetometer
+        // Device::write(&mut self.dev, Register::I2C_SLV0_ADDR, ak8963::I2C_ADDRESS | ak8963::R)?;
+        // Device::write(&mut self.dev, Register::I2C_SLV0_REG, ak8963::Register::XOUT_L.addr())?;
+        // Device::write(&mut self.dev, Register::I2C_SLV0_CTRL, 0x87)?;
 
-        // configure sampling of magnetometer
-        self.dev
-            .write(Register::I2C_SLV0_ADDR, ak8963::I2C_ADDRESS | ak8963::R)?;
-        self.dev
-            .write(Register::I2C_SLV0_REG, ak8963::Register::XOUT_L.addr())?;
-        self.dev.write(Register::I2C_SLV0_CTRL, 0x87)?;
-
-        delay.delay_ms(10);
+        log::trace!("Completed AK8963 initialization");
         Ok(())
     }
 
@@ -503,12 +495,13 @@ impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E>
     /// Reads and returns raw unscaled Accelerometer + Gyroscope + Thermometer
     /// + Magnetometer measurements (LSB).
     pub fn unscaled_all(&mut self) -> Result<UnscaledMargMeasurements, E> {
-        let buffer = self.dev.read_many::<U21>(Register::ACCEL_XOUT_H)?;
+        let atg_buffer = Device::read_many::<U15>(&mut self.dev, Register::ACCEL_XOUT_H)?;
+        let mag_buffer = AK8963::read_xyz(&mut self.dev)?;
 
-        let accel = self.to_vector(buffer, 0);
-        let temp = ((u16(buffer[7]) << 8) | u16(buffer[8])) as i16;
-        let gyro = self.to_vector(buffer, 8);
-        let mag = self.to_vector_inverted(buffer, 14);
+        let accel = self.to_vector(atg_buffer, 0);
+        let temp = ((u16(atg_buffer[7]) << 8) | u16(atg_buffer[8])) as i16;
+        let gyro = self.to_vector(atg_buffer, 8);
+        let mag = self.to_vector_inverted(mag_buffer, 0);
 
         Ok(UnscaledMargMeasurements { accel,
                                       gyro,
@@ -519,12 +512,13 @@ impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E>
     /// Reads and returns Accelerometer + Gyroscope + Thermometer + Magnetometer
     /// measurements scaled and converted to respective units.
     pub fn all(&mut self) -> Result<MargMeasurements, E> {
-        let buffer = self.dev.read_many::<U21>(Register::ACCEL_XOUT_H)?;
+        let atg_buffer = Device::read_many::<U15>(&mut self.dev, Register::ACCEL_XOUT_H)?;
+        let mag_buffer = AK8963::read_xyz(&mut self.dev)?;
 
-        let accel = self.scale_accel(buffer, 0);
-        let temp = self.scale_temp(buffer, 6);
-        let gyro = self.scale_gyro(buffer, 8);
-        let mag = self.scale_and_correct_mag(buffer, 14);
+        let accel = self.scale_accel(atg_buffer, 0);
+        let temp = self.scale_temp(atg_buffer, 6);
+        let gyro = self.scale_gyro(atg_buffer, 8);
+        let mag = self.scale_and_correct_mag(mag_buffer, 0);
 
         Ok(MargMeasurements { accel,
                               gyro,
@@ -548,14 +542,14 @@ impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E>
 
     /// Reads and returns raw unscaled Magnetometer measurements (LSB).
     pub fn unscaled_mag(&mut self) -> Result<Vector3<i16>, E> {
-        let buffer = self.dev.read_many::<U8>(Register::EXT_SENS_DATA_00)?;
+        let buffer = self.dev.read_xyz()?;
         Ok(self.to_vector_inverted(buffer, 0))
     }
 
     /// Read and returns Magnetometer measurements scaled, adjusted for factory
     /// sensitivities, and converted to Teslas.
     pub fn mag(&mut self) -> Result<Vector3<f32>, E> {
-        let buffer = self.dev.read_many::<U8>(Register::EXT_SENS_DATA_00)?;
+        let buffer = self.dev.read_xyz()?;
         Ok(self.scale_and_correct_mag(buffer, 0))
     }
 
@@ -580,7 +574,9 @@ impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E>
     fn _mag_scale(&mut self) -> Result<(), E> {
         // Set magnetometer data resolution and sample ODR
         let scale = self.mag_scale as u8;
-        self.ak8963_write(ak8963::Register::CNTL, scale << 4 | MMODE)?;
+        AK8963::write(&mut self.dev,
+                      ak8963::Register::CNTL,
+                      scale << 4 | MMODE)?;
         Ok(())
     }
 
@@ -595,7 +591,7 @@ impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E>
 
     /// Reads the AK8963 (magnetometer) WHO_AM_I register; should return `0x48`
     pub fn ak8963_who_am_i(&mut self) -> Result<u8, E> {
-        self.ak8963_read(ak8963::Register::WHO_AM_I)
+        AK8963::read(&mut self.dev, ak8963::Register::WHO_AM_I)
     }
 }
 
@@ -974,38 +970,6 @@ impl<E, DEV, MODE> Mpu9250<DEV, MODE> where DEV: Device<Error = E>
     /// Reads the WHO_AM_I register; should return `0x71`
     pub fn who_am_i(&mut self) -> Result<u8, E> {
         self.dev.read(Register::WHO_AM_I)
-    }
-
-    fn ak8963_read(&mut self, reg: ak8963::Register) -> Result<u8, E> {
-        self.dev
-            .write(Register::I2C_SLV4_ADDR, ak8963::I2C_ADDRESS | ak8963::R)?;
-        self.dev.write(Register::I2C_SLV4_REG, reg.addr())?;
-
-        // start transfer
-        self.dev.write(Register::I2C_SLV4_CTRL, 0x80)?;
-
-        // wait until transfer is over
-        while self.dev.read(Register::I2C_MST_STATUS)? & (1 << 6) == 0 {}
-
-        self.dev.read(Register::I2C_SLV4_DI)
-    }
-
-    fn ak8963_write(&mut self,
-                    reg: ak8963::Register,
-                    val: u8)
-                    -> Result<(), E> {
-        self.dev
-            .write(Register::I2C_SLV4_ADDR, ak8963::I2C_ADDRESS | ak8963::W)?;
-        self.dev.write(Register::I2C_SLV4_REG, reg.addr())?;
-        self.dev.write(Register::I2C_SLV4_DO, val)?;
-
-        // start transfer
-        self.dev.write(Register::I2C_SLV4_CTRL, 0x80)?;
-
-        // wait until transfer is over
-        while self.dev.read(Register::I2C_MST_STATUS)? & (1 << 6) == 0 {}
-
-        Ok(())
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -547,18 +547,14 @@ impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E> + AK8963<Error = E>
     fn init_ak8963<D>(&mut self, delay: &mut D) -> Result<(), E>
         where D: DelayMs<u8>
     {
-        log::trace!("Initializing AK8963...");
         AK8963::init(&mut self.dev, delay)?;
         delay.delay_ms(10);
         // First extract the factory calibration for each magnetometer axis
-        log::trace!("Powering down AK8963...");
         AK8963::write(&mut self.dev, ak8963::Register::CNTL, 0x00)?;
         delay.delay_ms(10);
         
-        log::trace!("Entering FUSE mode...");
         AK8963::write(&mut self.dev, ak8963::Register::CNTL, 0x0F)?;
         delay.delay_ms(20);
-        log::trace!("Reading calibration values...");
         let mag_x_bias = AK8963::read(&mut self.dev, ak8963::Register::ASAX)?;
         let mag_y_bias = AK8963::read(&mut self.dev, ak8963::Register::ASAY)?;
         let mag_z_bias = AK8963::read(&mut self.dev, ak8963::Register::ASAZ)?;
@@ -568,7 +564,6 @@ impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E> + AK8963<Error = E>
         self.mag_sensitivity_adjustments =
             self.raw_mag_sensitivity_adjustments
                 .map(|d| f32(d - 128) / 256. + 1.);
-        log::trace!("Magnetometer sensitivity adjustments = {:?}", self.mag_sensitivity_adjustments);
         AK8963::write(&mut self.dev, ak8963::Register::CNTL, 0x00)?;
         delay.delay_ms(10);
         // Set magnetometer data resolution and sample ODR
@@ -585,7 +580,6 @@ impl<E, DEV> Mpu9250<DEV, Marg> where DEV: Device<Error = E> + AK8963<Error = E>
         // Device::write(&mut self.dev, Register::I2C_SLV0_REG, ak8963::Register::XOUT_L.addr())?;
         // Device::write(&mut self.dev, Register::I2C_SLV0_CTRL, 0x87)?;
 
-        log::trace!("Completed AK8963 initialization");
         Ok(())
     }
 


### PR DESCRIPTION
The pull request attempts to generalize AK8963 across I2C and SPI devices. We add support for I2C bypass mode, which allows an I2C master to communicate directly with the AK8963 (address `0x0C`). As of this pull request, an I2C device may be used in MARG mode.

We introduce a new trait, `AK8963`, that encapsulates how to initialize the magnetometer (`init()` and `finalize()` methods), how to read / write `AK8963` registers (`read()` and `write()`), and how to acquired a magnetometer (x, y, z) triplet (`read_xyz()`). The behaviors are tied to the underlying communication protocol, so we provided implementations of each directly on `SpiDevice` and `I2cDevice`:

| `AK8963` Implementation | Initialization | Register I/O | Triplet acquisition |
| ---------------------------|-------------|-------------------|-------------|
| `SpiDevice` | Disables I2C master, and configures MPU's I2C_SLV4 for sampling | Read / Write MPU's I2C_SLV4 registers | Reads MPU's EXT_SENS_DATA_00 |
| `I2cDevice` | Enables I2C bypass mode | Direct I2C communication with AK8963 | Batch-read AK8963's XOUT_L through ST2 |

With this new trait in place, we provide an `MPU9250<DEV, Marg>` implementation that requires both a `Device` and a `AK8963` implementation on `DEV`. The MPU uses the new methods to interface with AK8963 without caring about the underlying protocol. The changes should be backwards-compatible.

The SPI behavior should remain unchanged; we just moved methods around. However, I don't have an MPU9250 available for testing with SPI, so please let me know if I broke something! Give it a test for me before we accept this, and let me know your thoughts.

We'll note that there's a middle-ground where we use I2C in master mode, configuring the MPU to service the AK8963 as an I2C master rather than enabling bypass. This didn't support my use-case. However, if there's a need, the implementation would effectively be the SPI implementation applied to the I2C device.