### PR TITLE
Fix faulty to_norm_quat computation

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1189,7 +1189,7 @@ impl<E, DEV> Mpu9250<DEV, Dmp> where DEV: Device<Error = E>
             f64::from(quat[0]),
             f64::from(quat[1]),
             f64::from(quat[2]),
-            f64::from(quat[2])
+            f64::from(quat[3])
         ];
         let sum = libm::sqrt(quat.iter().map(|x| libm::pow(*x, 2.0)).sum::<f64>());
         [


### PR DESCRIPTION
The fourth entry should be `f64::from(quat[3])`.

https://github.com/copterust/mpu9250/blob/005d8c65e4b1ea88a9947462df5d761afe0c2372/src/lib.rs#L1149-L1154