### PR TITLE
Fix peripheral hang: Stop communication with peripherals before resetting the main MPU

### DIFF
--- a/examples/rpi.rs
+++ b/examples/rpi.rs
@@ -41,7 +41,7 @@ fn main() {
     let ak8963_who_am_i = mpu9250.ak8963_who_am_i().unwrap();
 
     println!("WHO_AM_I: 0x{:x}", who_am_i);
-    println!("AK8963_WHO_AM_I: 0x{:x}", who_am_i);
+    println!("AK8963_WHO_AM_I: 0x{:x}", ak8963_who_am_i);
 
     assert_eq!(who_am_i, 0x71);
     assert_eq!(ak8963_who_am_i, 0x48);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1195,6 +1195,14 @@ impl<E, DEV, MODE> Mpu9250<DEV, MODE> where DEV: Device<Error = E>
     fn init_mpu<D>(&mut self, delay: &mut D) -> Result<(), E>
         where D: DelayMs<u8>
     {
+        // Stop all communication with peripherals (such as AK8963).
+        // If the chip is already powered up and if the communication is already running
+        // then resetting the MPU can result in a stuck peripheral that
+        // cannot be recovered from, except by physically powering down the peripheral.
+        self.dev.write(Register::I2C_SLV0_CTRL, 0).ok(); // Ignore error code.
+        self.dev.write(Register::I2C_SLV4_CTRL, 0).ok(); // Ignore error code.
+        delay.delay_ms(1); // Wait for transfer to finish.
+
         // wake up device
         self.dev.write(Register::PWR_MGMT_1, 0x80)?;
         delay.delay_ms(100); // Wait for all registers to reset


### PR DESCRIPTION
Stop communication with peripherals before resetting the main MPU.
The slave can get stuck, if the I2C master is reset during a transfer.

At this point in the program we don't know if the chip is actually doing transfers to a peripheral.
We don't even know, if there is a peripheral.
However, it seems safe enough to unconditionally disable the I2C master transceivers regardless of the current device state.

Also see the description of the I2C_MST_RST bit in the data sheet:
```
If this bit is set during an active I2C master transaction, the I2C slave
will hang, which will require the host to reset the slave.
```

This change fixes Issue #29