### PR TITLE
Make I2C address configurable

### DIFF
--- a/examples/bbblue.rs
+++ b/examples/bbblue.rs
@@ -12,13 +12,13 @@ use std::time::Duration;
 
 use hal::Delay;
 use hal::I2cdev;
-use mpu9250::Mpu9250;
+use mpu9250::{I2cAddress, Mpu9250};
 
 fn main() -> io::Result<()> {
     let i2c = I2cdev::new("/dev/i2c-2").expect("unable to open /dev/i2c-2");
 
     let mut mpu9250 =
-        Mpu9250::marg_default(i2c, &mut Delay).expect("unable to make MPU9250");
+        Mpu9250::marg_default(i2c, I2cAddress::AD0Low, &mut Delay).expect("unable to make MPU9250");
 
     let who_am_i = mpu9250.who_am_i().expect("could not read WHO_AM_I");
     let mag_who_am_i = mpu9250.ak8963_who_am_i()

--- a/examples/bbblue_dmp.rs
+++ b/examples/bbblue_dmp.rs
@@ -14,6 +14,7 @@ use std::io::{self, Write};
 use hal::sysfs_gpio;
 use hal::Delay;
 use hal::I2cdev;
+use mpu9250::I2cAddress;
 use mpu9250::DMP_FIRMWARE;
 use mpu9250::{Error, Mpu9250};
 
@@ -31,7 +32,7 @@ fn main() {
         writeln!(&mut stdout, "  Normalized quaternion").unwrap();
 
         let mut mpu9250 =
-            Mpu9250::dmp_default(i2c, &mut Delay, &DMP_FIRMWARE).expect("unable to load firmware");
+            Mpu9250::dmp_default(i2c,I2cAddress::AD0Low, &mut Delay, &DMP_FIRMWARE).expect("unable to load firmware");
 
         loop {
             match event.poll(1000).unwrap() {


### PR DESCRIPTION
- `I2cDevice::release` must return address in order for `reinit_i2c_device` to work
- Should `Mpu9250::release` return the address? If so, should it be `u8` or converted back to `I2cAddress`?
- Not sure what's the best place to convert `I2cAddress` to `u8`
- Obviously a breaking change in the function signatures